### PR TITLE
Add sensors that hold the results for the current day

### DIFF
--- a/custom_components/tibber_unofficial/const.py
+++ b/custom_components/tibber_unofficial/const.py
@@ -34,6 +34,11 @@ GRID_REWARDS_EV_YEAR = "grid_rewards_ev_year"
 GRID_REWARDS_HOMEVOLT_YEAR = "grid_rewards_homevolt_year"
 GRID_REWARDS_TOTAL_YEAR = "grid_rewards_total_year"
 
+# Current day grid rewards
+GRID_REWARDS_EV_CURRENT_DAY = "grid_rewards_ev_current_day"
+GRID_REWARDS_HOMEVOLT_CURRENT_DAY = "grid_rewards_homevolt_current_day"
+GRID_REWARDS_TOTAL_CURRENT_DAY = "grid_rewards_total_current_day"
+
 KEY_CURRENCY = "currency" # Unchanged
 
 # Attributes

--- a/custom_components/tibber_unofficial/sensor.py
+++ b/custom_components/tibber_unofficial/sensor.py
@@ -25,6 +25,9 @@ from .const import (
     GRID_REWARDS_EV_YEAR, 
     GRID_REWARDS_HOMEVOLT_YEAR,
     GRID_REWARDS_TOTAL_YEAR,
+    GRID_REWARDS_EV_CURRENT_DAY,
+    GRID_REWARDS_HOMEVOLT_CURRENT_DAY,
+    GRID_REWARDS_TOTAL_CURRENT_DAY,
     KEY_CURRENCY,
     COORDINATOR_REWARDS,
 )
@@ -33,12 +36,15 @@ from . import GridRewardsCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 SENSOR_DEFINITIONS = [
+    (GRID_REWARDS_EV_CURRENT_DAY, "EV - Current Day", "mdi:car-electric", "current_day_from", "current_day_to"),
     (GRID_REWARDS_EV_CURRENT_MONTH, "EV - Current Month", "mdi:car-electric", "current_month_from", "current_month_to"),
     (GRID_REWARDS_EV_PREVIOUS_MONTH, "EV - Previous Month", "mdi:car-electric", "previous_month_from", "previous_month_to"),
     (GRID_REWARDS_EV_YEAR, "EV - Year", "mdi:car-electric", "year_from", "year_to"),
+    (GRID_REWARDS_HOMEVOLT_CURRENT_DAY, "Homevolt - Current Day", "mdi:home-battery", "current_day_from", "current_day_to"),
     (GRID_REWARDS_HOMEVOLT_CURRENT_MONTH, "Homevolt - Current Month", "mdi:home-battery", "current_month_from", "current_month_to"),
     (GRID_REWARDS_HOMEVOLT_PREVIOUS_MONTH, "Homevolt - Previous Month", "mdi:home-battery", "previous_month_from", "previous_month_to"),
     (GRID_REWARDS_HOMEVOLT_YEAR, "Homevolt - Year", "mdi:home-battery", "year_from", "year_to"),
+    (GRID_REWARDS_TOTAL_CURRENT_DAY, "Total - Current Day", "mdi:cash-multiple", "current_day_from", "current_day_to"),
     (GRID_REWARDS_TOTAL_CURRENT_MONTH, "Total - Current Month", "mdi:cash-multiple", "current_month_from", "current_month_to"),
     (GRID_REWARDS_TOTAL_PREVIOUS_MONTH, "Total - Previous Month", "mdi:cash-multiple", "previous_month_from", "previous_month_to"),
     (GRID_REWARDS_TOTAL_YEAR, "Total - Year", "mdi:cash-multiple", "year_from", "year_to"),

--- a/readme.md
+++ b/readme.md
@@ -18,16 +18,23 @@ Contributions and feedback are welcome!
 This first release only supports the Grid Rewards for now in 9 sensors. I'm planning to add support for Homevolt, EV, EV Charger, Contract information, Solar Inverter. 
 
 ## Releases
+
+## v0.1.1
+Adds sensors that track the result of the current day.
+
 ## v0.1
 This is my first release and only supports the Tibber Grid Rewards earnings for now
 
 ### Sensors
+ - Grid Rewards EV - Current Day
  - Grid Rewards EV - Current Month
  - Grid Rewards EV - Previous Month
  - Grid Rewards EV - Current Year
+ - Grid Rewards Homevolt - Current Day
  - Grid Rewards Homevolt - Current Month
  - Grid Rewards Homevolt - Previous Month
  - Grid Rewards Homevolt - Current Year
+ - Grid Rewards Total - Current Day
  - Grid Rewards Total - Current Month
  - Grid Rewards Total - Previous Month
  - Grid Rewards Total - Current Year


### PR DESCRIPTION
In order to more easily synchronize the Tibber results to onbalansmarkt.com, this PR adds the results for the current day. It's untested as I don't have an Homevolt myself. 

Let me know if it's not functional and I can try to adjust that as needed.